### PR TITLE
Fix NPE in AliasFacade.findPsiClass(..)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'cn.wuzhizhan.idea.mybatis'
-version = '2018.05.17'
+version = '2018.06.06'
 
 apply plugin: 'java'
 sourceCompatibility = 1.8
@@ -23,9 +23,9 @@ intellij {
 }
 patchPluginXml {
     changeNotes """
-    <h4>2018.05.17</h4>
+    <h4>2019.06.06</h4>
       <ul>
-        <li>fix some bugs</li>
+        <li>Fix NPE in AliasFacade.findPsiClass(..)</li>
       </ul>
      """
 }

--- a/src/main/java/com/wuzhizhan/mybatis/alias/AliasFacade.java
+++ b/src/main/java/com/wuzhizhan/mybatis/alias/AliasFacade.java
@@ -59,7 +59,7 @@ public class AliasFacade {
         }
         for (AliasResolver resolver : resolvers) {
             for (AliasDesc desc : resolver.getClassAliasDescriptions(element)) {
-                if (desc.getAlias().equalsIgnoreCase(shortName)) {
+                if (shortName.equalsIgnoreCase(desc.getAlias())) {
                     return Optional.of(desc.getClazz());
                 }
             }
@@ -77,12 +77,12 @@ public class AliasFacade {
     }
 
     public Optional<AliasDesc> findAliasDesc(@Nullable PsiClass clazz) {
-        if (null == clazz) {
+        if (clazz == null) {
             return Optional.absent();
         }
         for (AliasResolver resolver : resolvers) {
             for (AliasDesc desc : resolver.getClassAliasDescriptions(clazz)) {
-                if (desc.getClazz().equals(clazz)) {
+                if (clazz.equals(desc.getClazz())) {
                     return Optional.of(desc);
                 }
             }


### PR DESCRIPTION
为没有 `@Alias("..")` 注解的实体类添加 `@Alias("..")` 注解时，出现异常

```
Error during processing of: ***Mapper.xml

java.lang.NullPointerException
	at com.wuzhizhan.mybatis.alias.AliasFacade.findPsiClass(AliasFacade.java:62)
	at com.wuzhizhan.mybatis.dom.converter.AliasConverter.fromString(AliasConverter.java:34)
	at com.wuzhizhan.mybatis.dom.converter.AliasConverter.fromString(AliasConverter.java:25)
	at com.intellij.util.xml.impl.GetInvocation.a(GetInvocation.java:99)
	at com.intellij.util.xml.impl.GetInvocation.a(GetInvocation.java:74)
	at com.intellij.util.xml.impl.GetInvocation.invoke(GetInvocation.java:62)
	at com.intellij.util.xml.impl.DomInvocationHandler.invoke(DomInvocationHandler.java:670)
	at com.intellij.util.xml.GenericAttributeValue$$EnhancerByJetBrainsMainCglib$$f4a47684.getValue(<generated>)
	at com.wuzhizhan.mybatis.dom.MapperBacktrackingUtils.getPropertyClazz(MapperBacktrackingUtils.java:51)
	at com.wuzhizhan.mybatis.reference.PsiFieldReferenceSetResolver.getStartElement(PsiFieldReferenceSetResolver.java:47)
	at com.wuzhizhan.mybatis.reference.ContextReferenceSetResolver.getStartElement(ContextReferenceSetResolver.java:56)
	at com.wuzhizhan.mybatis.reference.ContextReferenceSetResolver.resolve(ContextReferenceSetResolver.java:38)
	at com.wuzhizhan.mybatis.reference.ContextPsiFieldReference.resolve(ContextPsiFieldReference.java:38)

...
```